### PR TITLE
support non-empty-array<Product>.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Features
+
+ * support non-empty-array<Product>. If `non-empty-array` is specified, change the dependency arrow caption from `*` to `1..*` #55
+
 ## v1.2.4 (2024-01-08)
 
 ### Bug fix

--- a/src/DiagramElement/ArrowDependency.php
+++ b/src/DiagramElement/ArrowDependency.php
@@ -14,17 +14,27 @@ final class ArrowDependency extends Arrow
     {
         if (strpos($this->getTo()->getName(), '[]') !== false) {
             // ex. Product[]
-            return $this->getExpression($toClass);
+            return $this->getExpression($toClass, false);
         }
         if (strpos($this->getTo()->getName(), 'array<') === 0) {
             // ex. array<Product> or array<int, Product>
-            return $this->getExpression($toClass);
+            return $this->getExpression($toClass, false);
+        }
+        if (strpos($this->getTo()->getName(), 'non-empty-array<') === 0) {
+            // ex. non-empty-array<Product> or non-empty-array<int, Product>
+            return $this->getExpression($toClass, true);
         }
         return sprintf('  %s %s %s', $this->getFrom()->getClassNameAlias(), $this->figure, $toClass->getClassNameAlias());
     }
 
-    private function getExpression(PhpClass $toClass): string
+    private function getExpression(PhpClass $toClass, bool $nonEmpty): string
     {
-        return sprintf('  %s "1" %s "*" %s', $this->getFrom()->getClassNameAlias(), $this->figure, str_replace('[]', '', $toClass->getClassNameAlias()));
+        return sprintf(
+            '  %s "1" %s "%s" %s',
+            $this->getFrom()->getClassNameAlias(),
+            $this->figure,
+            $nonEmpty ? '1..*' : '*',
+            str_replace('[]', '', $toClass->getClassNameAlias())
+        );
     }
 }

--- a/test/RelationTest.php
+++ b/test/RelationTest.php
@@ -135,8 +135,9 @@ final class RelationTest extends TestCase
         $rel = new Relation($entries, $options);
         $relations = $rel->getRelations();
 
-        $this->assertSame(1, count($relations), 'count');
-        $this->assertSame('  product_Product "1" ..> "*" product_Tag', $relations[0], 'relation 1');
+        $this->assertSame(2, count($relations), 'count');
+        $this->assertSame('  product_Product "1" ..> "*" product_Tag', $relations[0], 'relation *');
+        $this->assertSame('  product_Product "1" ..> "1..*" product_Tag', $relations[1], 'relation 1..*');
     }
 
     public function testGetRelations_extends1(): void

--- a/test/fixtures/array-expression-in-doc/product/Product.php
+++ b/test/fixtures/array-expression-in-doc/product/Product.php
@@ -5,6 +5,9 @@ class Product {
     /** @var array<Tag> */
     private array $tags = [];
 
+    /** @var non-empty-array<Tag> */
+    private array $nonEmptytags;
+
     /**
      * @return array<Tag>
      */


### PR DESCRIPTION
If `non-empty-array` is specified, change the dependency arrow caption from `*` to `1..*` #55

fixed #55