### PR TITLE
Improve Main class

### DIFF
--- a/bin/php-class-diagram
+++ b/bin/php-class-diagram
@@ -1,15 +1,23 @@
 #!/usr/bin/env php
 <?php declare(strict_types=1);
+
 namespace Smeghead\PhpClassDiagram;
 
-foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
+use Smeghead\PhpClassDiagram\Config\Options;
+
+foreach (
+    [
+        __DIR__ . '/../../../autoload.php',
+        __DIR__ . '/../vendor/autoload.php'
+    ] as $file
+) {
     if (file_exists($file)) {
         require $file;
         break;
     }
 }
 
-$options = getopt('hv',[
+$options = getopt('hv', [
     'help',
     'version',
     'class-diagram',
@@ -31,7 +39,7 @@ $options = getopt('hv',[
 ], $rest_index);
 $arguments = array_slice($argv, $rest_index);
 
-$usage =<<<EOS
+$usage = <<<EOS
 usage: php-class-diagram [OPTIONS] <target php source directory>
 
 A CLI tool that parses the PHP source directory and generates PlantUML class diagram scripts as output.
@@ -60,28 +68,25 @@ OPTIONS
 EOS;
 
 if (isset($options['v']) || isset($options['version'])) {
-    fputs(STDERR, sprintf('php-class-diagram %s%s', \Smeghead\PhpClassDiagram\Main::VERSION, PHP_EOL));
+    fwrite(STDERR, sprintf('php-class-diagram %s%s', Main::VERSION, PHP_EOL));
     exit(-1);
 }
 if (isset($options['h']) || isset($options['help'])) {
-    fputs(STDERR, $usage);
+    fwrite(STDERR, $usage);
     exit(-1);
 }
 
 $directory = array_shift($arguments);
 if (empty($directory)) {
-    fputs(STDERR, "ERROR: not specified php source file.\n");
-    fputs(STDERR, $usage);
+    fwrite(STDERR, "ERROR: not specified php source file.\n");
+    fwrite(STDERR, $usage);
     exit(-1);
 }
-if ( ! is_dir($directory)) {
-    fputs(STDERR, sprintf("ERROR: specified directory dose not exists. directory: %s\n", $directory));
-    fputs(STDERR, $usage);
+if (!is_dir($directory)) {
+    fwrite(STDERR, sprintf("ERROR: specified directory dose not exists. directory: %s\n", $directory));
+    fwrite(STDERR, $usage);
     exit(-1);
 }
-
-use Smeghead\PhpClassDiagram\Config\Options;
-use Smeghead\PhpClassDiagram\Main;
 
 $main = new Main($directory, new Options($options));
 $main->run();

--- a/bin/php-class-diagram
+++ b/bin/php-class-diagram
@@ -83,4 +83,5 @@ if ( ! is_dir($directory)) {
 use Smeghead\PhpClassDiagram\Config\Options;
 use Smeghead\PhpClassDiagram\Main;
 
-new Main($directory, new Options($options));
+$main = new Main($directory, new Options($options));
+$main->run();

--- a/src/Config/Options.php
+++ b/src/Config/Options.php
@@ -16,7 +16,7 @@ final class Options
     public const DIAGRAM_CLASS = 'class';
     public const DIAGRAM_PACKAGE = 'package';
     public const DIAGRAM_JIG = 'jig';
-    public const DIAGRAM_DIVSION = 'division';
+    public const DIAGRAM_DIVISION = 'division';
 
     /**
      * @param array<string, mixed> $opt Option array
@@ -49,7 +49,7 @@ final class Options
             return self::DIAGRAM_JIG;
         }
         if (isset($this->opt['division-diagram'])) {
-            return self::DIAGRAM_DIVSION;
+            return self::DIAGRAM_DIVISION;
         }
         // default
         return self::DIAGRAM_CLASS;

--- a/src/Main.php
+++ b/src/Main.php
@@ -25,9 +25,7 @@ final class Main
     {
         $finder = $this->createFinder();
         $entries = $this->findEntries($finder);
-
-        $relation = new Relation($entries, $this->options);
-        $this->renderRelations($relation);
+        $this->renderEntries($entries);
     }
 
     private function createFinder(): Finder
@@ -67,8 +65,13 @@ final class Main
         return $entries;
     }
 
-    private function renderRelations(Relation $relation): void
+    /**
+     * @param list<Entry> $entries
+     */
+    private function renderEntries(array $entries): void
     {
+        $relation = new Relation($entries, $this->options);
+
         switch ($this->options->diagram()) {
             case Options::DIAGRAM_CLASS:
                 echo implode("\r\n", $relation->dump()) . "\r\n";

--- a/src/Main.php
+++ b/src/Main.php
@@ -6,7 +6,8 @@ namespace Smeghead\PhpClassDiagram;
 
 use RuntimeException;
 use Smeghead\PhpClassDiagram\Config\Options;
-use Smeghead\PhpClassDiagram\DiagramElement\{Entry, Relation,};
+use Smeghead\PhpClassDiagram\DiagramElement\Entry;
+use Smeghead\PhpClassDiagram\DiagramElement\Relation;
 use Smeghead\PhpClassDiagram\Php\PhpReader;
 use Symfony\Component\Finder\Finder;
 

--- a/src/Main.php
+++ b/src/Main.php
@@ -72,22 +72,13 @@ final class Main
     {
         $relation = new Relation($entries, $this->options);
 
-        switch ($this->options->diagram()) {
-            case Options::DIAGRAM_CLASS:
-                $this->renderDiagramClass($relation);
-                break;
-            case OPTIONS::DIAGRAM_PACKAGE:
-                $this->renderDiagramPackage($relation);
-                break;
-            case OPTIONS::DIAGRAM_JIG:
-                $this->renderDiagramJig($relation);
-                break;
-            case OPTIONS::DIAGRAM_DIVSION:
-                $this->renderDiagramVivsion($relation);
-                break;
-            default:
-                throw new RuntimeException('invalid diagram.');
-        }
+        match ($this->options->diagram()) {
+            Options::DIAGRAM_CLASS => $this->renderDiagramClass($relation),
+            OPTIONS::DIAGRAM_PACKAGE => $this->renderDiagramPackage($relation),
+            OPTIONS::DIAGRAM_JIG => $this->renderDiagramJig($relation),
+            OPTIONS::DIAGRAM_DIVSION => $this->renderDiagramVivsion($relation),
+            default => throw new RuntimeException('invalid diagram.')
+        };
     }
 
     private function renderDiagramClass(Relation $relation): void

--- a/src/Main.php
+++ b/src/Main.php
@@ -74,21 +74,41 @@ final class Main
 
         switch ($this->options->diagram()) {
             case Options::DIAGRAM_CLASS:
-                echo implode("\r\n", $relation->dump()) . "\r\n";
+                $this->renderDiagramClass($relation);
                 break;
             case OPTIONS::DIAGRAM_PACKAGE:
-                echo implode("\r\n", $relation->dumpPackages()) . "\r\n";
+                $this->renderDiagramPackage($relation);
                 break;
             case OPTIONS::DIAGRAM_JIG:
-                echo implode("\r\n", $relation->dump()) . "\r\n";
-                echo implode("\r\n", $relation->dumpPackages()) . "\r\n";
-                echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
+                $this->renderDiagramJig($relation);
                 break;
             case OPTIONS::DIAGRAM_DIVSION:
-                echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
+                $this->renderDiagramVivsion($relation);
                 break;
             default:
                 throw new RuntimeException('invalid diagram.');
         }
+    }
+
+    private function renderDiagramClass(Relation $relation): void
+    {
+        echo implode("\r\n", $relation->dump()) . "\r\n";
+    }
+
+    private function renderDiagramPackage(Relation $relation): void
+    {
+        echo implode("\r\n", $relation->dumpPackages()) . "\r\n";
+    }
+
+    private function renderDiagramJig(Relation $relation): void
+    {
+        echo implode("\r\n", $relation->dump()) . "\r\n";
+        echo implode("\r\n", $relation->dumpPackages()) . "\r\n";
+        echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
+    }
+
+    private function renderDiagramVivsion(Relation $relation): void
+    {
+        echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
     }
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -60,7 +60,7 @@ final class Main
                     $entries[] = new Entry($file->getRelativePath(), $reflection->getInfo(), $this->options);
                 }
             } catch (\Exception $e) {
-                fputs(STDERR, $e->getMessage() . "\r\n");
+                fwrite(STDERR, $e->getMessage() . "\r\n");
             }
         }
         return $entries;

--- a/src/Main.php
+++ b/src/Main.php
@@ -76,7 +76,7 @@ final class Main
             Options::DIAGRAM_CLASS => $this->renderDiagramClass($relation),
             OPTIONS::DIAGRAM_PACKAGE => $this->renderDiagramPackage($relation),
             OPTIONS::DIAGRAM_JIG => $this->renderDiagramJig($relation),
-            OPTIONS::DIAGRAM_DIVSION => $this->renderDiagramVivsion($relation),
+            OPTIONS::DIAGRAM_DIVISION => $this->renderDiagramDivision($relation),
             default => throw new RuntimeException('invalid diagram.')
         };
     }
@@ -98,7 +98,7 @@ final class Main
         echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
     }
 
-    private function renderDiagramVivsion(Relation $relation): void
+    private function renderDiagramDivision(Relation $relation): void
     {
         echo implode("\r\n", $relation->dumpDivisions()) . "\r\n";
     }

--- a/test/OptionsTest.php
+++ b/test/OptionsTest.php
@@ -178,7 +178,7 @@ final class OptionsTest extends TestCase
 
         $options = new Options($opt);
 
-        $this->assertSame(Options::DIAGRAM_DIVSION, $options->diagram(), 'diagram is division.');
+        $this->assertSame(Options::DIAGRAM_DIVISION, $options->diagram(), 'diagram is division.');
     }
     public function testDiagram3(): void
     {


### PR DESCRIPTION
## 📚  Description 

Avoid having logic in the constructor. Rather, extract that logic in a public method.
Also, split the logic into smaller private methods to improve readability. 