### PR TITLE
Fix svg link double slashes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM plantuml/plantuml
 
-RUN apt-get update && apt-get install -y php8.1-cli php-xml composer fonts-noto-cjk && apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y php8.1-cli php-xml php-mbstring php-xdebug fonts-noto-cjk && apt-get clean && rm -rf /var/lib/apt/lists/*
 RUN echo '#!/bin/sh' > /usr/bin/plantuml && echo 'java -jar /opt/plantuml.jar "$@"' >> /usr/bin/plantuml && chmod +x /usr/bin/plantuml
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer

--- a/compose.yaml
+++ b/compose.yaml
@@ -6,4 +6,5 @@ services:
       dockerfile: ./Dockerfile
     working_dir: /usr/src
     volumes:
+      - ./php.ini:/etc/php/8.1/cli/conf.d/php.ini
       - ./:/usr/src

--- a/php.ini
+++ b/php.ini
@@ -1,0 +1,10 @@
+[xdebug]
+# for Windows Docker host.
+#xdebug.client_host = host.docker.internal
+# for Linux Docker host.
+xdebug.client_host = localhost
+xdebug.mode = debug
+xdebug.start_with_request = yes
+xdebug.discover_client_host = 0
+xdebug.remote_handler = "dbgp"
+xdebug.client_port = 9003

--- a/src/DiagramElement/Entry.php
+++ b/src/DiagramElement/Entry.php
@@ -190,7 +190,10 @@ final class Entry
         if (empty($this->options->svgTopurl())) {
             return '';
         }
-        $path = sprintf('/%s/%s.php', $this->directory, $this->class->getClassType()->getName());
+        $path = sprintf(
+            '/%s%s.php',
+            empty($this->directory) ? '' : sprintf('%s/', $this->directory),
+            $this->class->getClassType()->getName());
         return sprintf(
             ' [[%s %s %s]]',
             $path,


### PR DESCRIPTION
Fixed a case where two slashes overlapped in the path when generating SVG links.

Even when two path slashes overlapped, there was no problem with the link behavior itself.