### PR TITLE
feat: symmetric visibility constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### Features
+
+ * feat: support AsymmetricVisibility in constructor promotion.
+
 ## v1.4.1 (2024-09-22)
 
 ### Features

--- a/src/Php/Finders/FindConstructerProperties.php
+++ b/src/Php/Finders/FindConstructerProperties.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Smeghead\PhpClassDiagram\Php\Finders;
 
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Param;
-use PhpParser\Node\Stmt\Class_;
 use PhpParser\Node\Stmt\ClassLike;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\NodeFinder;
@@ -29,11 +29,17 @@ final class FindConstructerProperties
         }
         $this->constructer = $constructer;
         foreach ($constructer->getParams() as $p) {
-            if ($p->flags & Class_::MODIFIER_PUBLIC) {
+            if ($p->flags & Modifiers::PUBLIC) {
                 $this->properties[] = $p;
-            } else if ($p->flags & Class_::MODIFIER_PRIVATE) {
+            } else if ($p->flags & Modifiers::PRIVATE) {
                 $this->properties[] = $p;
-            } else if ($p->flags & Class_::MODIFIER_PROTECTED) {
+            } else if ($p->flags & Modifiers::PROTECTED) {
+                $this->properties[] = $p;
+            } else if ($p->flags & Modifiers::PUBLIC_SET) {
+                $this->properties[] = $p;
+            } else if ($p->flags & Modifiers::PROTECTED_SET) {
+                $this->properties[] = $p;
+            } else if ($p->flags & Modifiers::PRIVATE_SET) {
                 $this->properties[] = $p;
             }
         }

--- a/src/Php/PhpAccessModifier.php
+++ b/src/Php/PhpAccessModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Smeghead\PhpClassDiagram\Php;
 
+use PhpParser\Modifiers;
 use PhpParser\Node\Param;
 use PhpParser\Node\Stmt\{
     Class_,
@@ -24,9 +25,9 @@ final class PhpAccessModifier
     public function __construct(ClassConst|Property|ClassMethod|Param $stmt)
     {
         if ($stmt instanceof Param) {
-            $this->public = (bool)($stmt->flags & Class_::MODIFIER_PUBLIC);
-            $this->protected = (bool)($stmt->flags & Class_::MODIFIER_PROTECTED);
-            $this->private = (bool)($stmt->flags & Class_::MODIFIER_PRIVATE);
+            $this->public = $this->parseFlagsPublic($stmt->flags);
+            $this->protected = (bool)($stmt->flags & Modifiers::PROTECTED);
+            $this->private = (bool)($stmt->flags & Modifiers::PRIVATE);
         } else {
             $this->public = $stmt->isPublic();
             $this->protected = $stmt->isProtected();
@@ -36,6 +37,23 @@ final class PhpAccessModifier
                 $this->abstract = $stmt->isAbstract();
             }
         }
+    }
+
+    private function parseFlagsPublic(int $flags): bool
+    {
+        if ($flags & Modifiers::PUBLIC) {
+            return true;
+        }
+        if ($flags & Modifiers::PUBLIC_SET) {
+            return true;
+        }
+        if ($flags & Modifiers::PROTECTED_SET) {
+            return true;
+        }
+        if ($flags & Modifiers::PRIVATE_SET) {
+            return true;
+        }
+        return false;
     }
 
     public function isPublic(): bool

--- a/src/Php/PhpProperty.php
+++ b/src/Php/PhpProperty.php
@@ -46,6 +46,7 @@ final class PhpProperty
             $class->getUses()
         );
         $instance->accessModifier = new PhpAccessModifier($param);
+        $instance->hooksState = '';
         return $instance;
     }
 

--- a/test/AsymmetricVisibilityTest.php
+++ b/test/AsymmetricVisibilityTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+use Smeghead\PhpClassDiagram\Config\Options;
+use Smeghead\PhpClassDiagram\DiagramElement\{
+    Relation,
+    Entry,
+};
+use Smeghead\PhpClassDiagram\Php\PhpReader;
+
+final class AsymmetricVisibilityTest extends TestCase
+{
+    private string $fixtureDir;
+
+    public function setUp(): void
+    {
+        $this->fixtureDir = sprintf('%s/fixtures', __DIR__);
+    }
+
+    public function tearDown(): void
+    {
+        $this->fixtureDir = '';
+    }
+
+    public function testDump_AsymmetricVisibility(): void
+    {
+        $directory = sprintf('%s/asymmetric-visibility', $this->fixtureDir);
+        $options = new Options([
+        ]);
+        $files = [
+            'AsymmetricVisibility.php',
+        ];
+
+        $rel = $this->getRelation($directory, $options, $files);
+
+        $expected = <<<EOS
+@startuml class-diagram
+  class "AsymmetricVisibility" as AsymmetricVisibility {
+    +param1 : int
+    -param2 : int
+    +name : string
+    +amount : int
+    +rate : float
+    +__construct(param1, param2, name, amount, rate)
+  }
+@enduml
+EOS;
+        $this->assertSame($expected, implode(PHP_EOL, $rel->dump()), 'output PlantUML script.');
+    }
+
+    /**
+     * @param string[] $files
+     */
+    private function getRelation(string $directory, Options $options, array $files): Relation
+    {
+        $entries = [];
+        foreach ($files as $f) {
+            $filename = sprintf('%s/%s', $directory, $f);
+            $classes = PhpReader::parseFile($directory, $filename, $options);
+            $d = dirname($f);
+            if ($d === '.') {
+                $d = '';
+            }
+            $entries[] = array_map(fn($c) => new Entry($d, $c->getInfo(), $options), $classes);
+        }
+
+        return new Relation(array_merge(...$entries), $options);
+    }
+}

--- a/test/fixtures/asymmetric-visibility/AsymmetricVisibility.php
+++ b/test/fixtures/asymmetric-visibility/AsymmetricVisibility.php
@@ -1,0 +1,13 @@
+<?php
+class AsymmetricVisibility
+{
+    public function __construct(
+        public int $param1,
+        private int $param2,
+        public private(set) string $name,
+        private(set) int $amount,
+        protected(set) float $rate
+    )
+    {        
+    }
+}


### PR DESCRIPTION
Support for AsymmetricVisibility, a new feature in PHP 8.4.

The AsymmetricVisibility notation is now supported in the class constructor promotion.