### PR TITLE
docs: Improve documentation for the --exclude option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ $ vendor/bin/php-class-diagram \
 
 #### option `exclude`
 
-You can specify patterns to exclude files from the processing.
+You can specify patterns to exclude files from the processing. If you want to ignore a folder, you must specify the relative path to the target php source directory.
 
 ```bash
 $ vendor/bin/php-class-diagram \


### PR DESCRIPTION
I think that the docs for the exclude option need a bit of clarification about excluding folders. I was a bit confused when trying to exclude folders until I read the documentation of Symfony Finder Component, but with just a few words I think its clearer.