### PR TITLE
fix: allow paths with hyphens

### DIFF
--- a/src/Php/PhpClass.php
+++ b/src/Php/PhpClass.php
@@ -76,7 +76,7 @@ final class PhpClass
      */
     public function getClassNameAlias(): string
     {
-        return str_replace(['.', '[', ']'], '_', $this->getLogicalName());
+        return str_replace(['-', '.', '[', ']'], ['', '_', '_', '_'], $this->getLogicalName());
     }
 
     public function getClassType(): PhpType


### PR DESCRIPTION
While trying to create a diagram of a complete application, I've noticed that PlantUml has problems if any file path includes dashes. With this pull request I've made a minimal change to correct this, but I'm not able to write a unit test that doesn't involve testing many parts of php-class-diagram. I could use some help testing this change.

Thanks a lot